### PR TITLE
Fix grunt task name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If not present, the suffix of source file name is used instead.
 
 ```js
 grunt.initConfig({
-  split_file: {
+  splitfile: {
     options: {
       separator: 'abc',
       prefix: [ "1", "2" ]


### PR DESCRIPTION
Otherwise getting: Warning: Task "split_file" not found. Use --force to continue.
